### PR TITLE
add lazy decoding of text values

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1834,13 +1834,16 @@ class PgoutputReader extends BinaryReader {
             get() {
               const valtext = decoder.decode(valbuf);
               const value = PgType.decode(valtext, typeOid);
+              this[name] = value;
+              return value;
+            },
+            set(value) {
               Object.defineProperty(this, name, {
                 value,
-                configurable: false,
+                configurable: true,
                 enumerable: true,
-                writable: false,
+                writable: true,
               })
-              return value;
             }
           })
           break;


### PR DESCRIPTION
Implements lazy decoding by using getters instead of defining concrete values
It is kind of a breaking change since it changes what the object contains from value to getter
Closes #16 