### PR TITLE
Fix decoding of empty arrays

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -2307,9 +2307,12 @@ class PgType {
       else if (inQuotes); // continue
       else if (ch == 0x7b /*{*/) stack.unshift([]), elStart = i + 1;
       else if (ch == 0x7d /*}*/ || ch == 0x2c /*,*/) { // TODO configurable delimiter
+        let empty = false;
         if (!result) {
           const escaped = text.slice(elStart, i); // TODO trim ' \t\n\r\v\f'
-          if (!/^NULL$/ui.test(escaped)) {
+          if (escaped == '') {
+            empty = true;
+          } if (!/^NULL$/ui.test(escaped)) {
             result = escaped.replace(/^"|"$|(?<!\\)\\/ug, '');
             // TODO accept decodeFn as argument,
             // extract parseArray logic out of decoder,
@@ -2317,7 +2320,9 @@ class PgType {
             result = this.decode(result, elemTypeOid);
           }
         }
-        stack[0].push(result);
+        if (!empty) {
+          stack[0].push(result);
+        }
         result = ch == 0x7d /*}*/ ? stack.shift() : null;
         elStart = i + 1; // TODO dry
       }

--- a/test/test.js
+++ b/test/test.js
@@ -426,7 +426,9 @@ export function setup({
       ARRAY['"quoted"', '{string}', '"{-,-}"', e'\t'],
       ARRAY[[1, 2], [3, 4]],
       '[1:1][-2:-1][3:5]={{{1,2,3},{4,5,6}}}'::int[],
-      ARRAY[1, NULL, 2]
+      ARRAY[1, NULL, 2],
+      ARRAY[]::text[],
+      ARRAY[]::int[]
     `;
     const expected = [
       null,
@@ -450,6 +452,8 @@ export function setup({
       [[1, 2], [3, 4]],
       [[[1, 2, 3], [4, 5, 6]]],
       [1, null, 2],
+      [],
+      []
     ]
     const conn = await pgconnect('postgres://pgwire@pgwssl:5432/postgres');
     try {


### PR DESCRIPTION
Previously `ARRAY[]::text[]` and `ARRAY[]::int[]` were decoded as `['']` and `[0]` respectively - this fixes it to be decoded as `[]`.
