### PR TITLE
NodeJS: Only read as much data as requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,14 +89,14 @@ class SocketAdapter {
     for (;;) {
       if (this._error) throw this._error; // TODO callstack
       if (this._socket.readableEnded) return null;
-      buf = this._socket.read();
+      const toRead = Math.min(out.length, this._socket.readableLength);
+      buf = this._socket.read(toRead);
+
       if (buf?.length) break;
       if (!buf) await new Promise(this._readPauseAsync);
     }
     if (buf.length > out.length) {
-      out.set(buf.subarray(0, out.length));
-      this._socket.unshift(buf.subarray(out.length));
-      return out.length;
+      throw new Error('Read more data than expected');
     }
     out.set(buf);
     return buf.length;


### PR DESCRIPTION
The version would read all data available on the socket using `_socket.read()`, then `unshift()` data back onto the socket if too much was read. This caused two issues:

1. This bypassed back-pressure on the socket (the `readableHighWaterMark`), which meant that the internal buffer could grow without bounds when doing large queries (say doing a streaming query with 1GB of data).
2. As the buffer grows, read + unshift becomes slower. So reads slow down, which in turn means the internal buffer just grows even further, compounding the issue.

The fix is to just read as much data as requested with the `out` buffer.

